### PR TITLE
Fixup

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,7 @@
-Before adding your name to this file, you must read and agree to the CLA in CONTRIBUTING.md in the master branch of the repository to which you are contributing.
+Before adding your name to this file, you must read and agree to the CLA in
+CONTRIBUTING.md in the master branch of the repository to which you are
+contributing.
 
 Full Name   Email   Date    CLA Signature Statement
 Daniel Kumor    daniel@dkumor.com   2015-11-25  Adding myself to this file constitutes my signature on the CLA given in CONTRIBUTING.md at http://github.com/connectordb/connectordb-javascript. I have read and agree to be bound by the CLA therein.
+Joseph Lewis    joseph@josephlewis.net   2015-11-25  Adding myself to this file constitutes my signature on the CLA given in CONTRIBUTING.md at http://github.com/connectordb/connectordb-javascript. I have read and agree to be bound by the CLA therein.

--- a/connectordb.js
+++ b/connectordb.js
@@ -1,4 +1,10 @@
+/** This file is part of the ConnectorDB project.
 
+Copyright 2016 the ConnectorDB contributors, see AUTHORS for a list of
+contributors.
+
+Licensed under the MIT license.
+**/
 "use strict";
 
 function ConnectorDB(device, apikey, url) {
@@ -7,7 +13,7 @@ function ConnectorDB(device, apikey, url) {
     this.url = url + "/api/v1/"
 
     this.device = device;
-    
+
     this.authHeader = "Basic " + btoa(device + ":" + apikey);
 
 }
@@ -30,6 +36,7 @@ ConnectorDB.prototype = {
 
         return new Promise(function(resolve, reject) {
             var req = new XMLHttpRequest();
+            //req.withCredentials = true;
 
             // type, url, async, basicauth credentials
             req.open(reqtype, url, true);
@@ -189,4 +196,111 @@ ConnectorDB.prototype = {
         var path = this._getPath(username, devicename, streamname) + "/data?t1=" + t1 + "&t2=" + t2 + "&limit=" + limit;
         return this._doRequest(path, "GET");
     },
+
+    // Gets a list of available transforms on the system.
+    getTransforms: function() {
+        return this._doRequest("meta/transforms", "GET")
+    },
+
+    // Gets a list of available transforms on the system.
+    getInterpolators: function() {
+        return this._doRequest("meta/interpolators", "GET")
+    },
+
+    query: function() {
+
+    }
+
+    merge: function(user, device, stream) {
+
+        return new StreamQuery(this, user, device, stream);
+    }
 };
+
+/**
+The steramquery can be used to run a query on a single stream in the following
+manner:
+
+sq = new StreamQuery(cdb, "foo", "bar", "baz")
+                .betweenIndex(0, 1000)
+                .transform("average")
+                .run()
+
+this would query the first 1000 datapoints in foo/bar/baz and average them.
+
+**/
+function StreamQuery(connectordb, user, device, stream) {
+    this.connectordb = connectordb;
+    this.user = user;
+    this.device = device;
+    this.stream = stream;
+    this.internal = {};
+    this.internal["stream"] = user + "/" + device + "/" + stream;
+}
+
+
+
+StreamQuery.prototype = {
+    run: function() {
+        return this.connectordb._doRequest(this.user, this.device, this.stream, this.internal);
+    },
+
+    betweenTime: function (start, end) {
+        // Set the start and end times
+        this.internal["t1"] = start;
+        this.internal["t2"] = end;
+
+        // Remove indicies since we need one or the other
+        this.internal.delete("i1");
+        this.internal.delete("i2");
+        return this;
+    },
+
+    betweenIndex: function(start, end) {
+        this.internal["i1"] = start;
+        this.internal["i2"] = end;
+
+        // Remove times since we need one or the other
+        this.internal.delete("t1");
+        this.internal.delete("t2");
+
+        return this;
+    },
+
+    // Limits the number of datapoints returned to the given amount
+    // -1 for unlimited
+    limit: function(numberOfDatapoints) {
+        this.internal.delete("limit");
+
+        if (numberOfDatapoints > 0) {
+            this.internal["limit"] = numberOfDatapoints;
+        }
+
+        return this;
+    },
+
+    // Sets the transform for this query, use "" to unset a transform.
+    transform: function(transform) {
+        this.internal.delete("transform");
+
+        if(transform != "") {
+            this.internal["transform"] = transform;
+        }
+
+        return this;
+    },
+};
+
+/**
+
+type DatasetQuery struct {
+	StreamQuery                                   //This is used for Ydatasets - setting the Stream variable will make it a Ydataset - it also holds the range
+	Merge         []*StreamQuery                  `json:"merge,omitempty"`      //optional merge for Ydatasets
+	Dt            float64                         `json:"dt,omitempty"`         //Used for TDatasets - setting this variable makes it a time based query
+	Dataset       map[string]*DatasetQueryElement `json:"dataset"`              //The dataset to generate
+	PostTransform string                          `json:"itransform,omitempty"` //The transform to run on the full datapoint after the dataset element is created
+}
+
+
+ConnectorDB.prototype = {
+**/

--- a/connectordb_test.js
+++ b/connectordb_test.js
@@ -151,6 +151,23 @@ describe("ConnectorDB admin user", function () {
         }).then(done);
     });
 
+
+    it("should be able to filter stream", function (done) {
+        var merger = cdb.merge()
+        merger.addStream("javascript_test", "testdevice", "mystream")
+                .betweenIndex(0, 1)
+                .transform("3 | sum")
+
+        merger.run()
+        .then(function (result) {
+            console.log(result);
+            expect(result[0].d).toBe(3);
+        }).catch(function (error) {
+            console.log(error);
+            expect(error).toBeUndefined();
+        }).then(done);
+    });
+
     it("should be able to delete stream", function (done) {
         cdb.deleteStream("javascript_test", "testdevice","mystream").then(function (result) {
             expect(result).toBe("ok");
@@ -174,4 +191,5 @@ describe("ConnectorDB admin user", function () {
             expect(error).toBeUndefined();
         }).then(done);
     });
+
 });

--- a/connectordb_test.js
+++ b/connectordb_test.js
@@ -8,6 +8,7 @@ describe("ConnectorDB admin user", function () {
         cdb.readUser("test").then(function (result) {
             expect(result.admin).toBe(true);
         }).catch(function (error) {
+            console.log(error);
             expect(error).toBeUndefined();
         }).then(done)
     });
@@ -58,9 +59,16 @@ describe("ConnectorDB admin user", function () {
 
     it("should be able to list devices", function (done) {
         cdb.listDevices("javascript_test").then(function (result) {
-            expect(result.length).toBe(2);
-            expect(result[0].name).toBe("user");
-            expect(result[1].name).toBe("testdevice");
+            expect(result.length).toBe(3);
+            var output = new Set();
+            result.forEach(function(element){
+                output.add(element.name);
+            });
+
+            var expected = new Set(["user", "meta", "testdevice"]);
+            expect(output).toEqual(expected);
+            /**expect(result[0].name).toBe("user");
+            expect(result[1].name).toBe("testdevice");**/
         }).catch(function (error) {
             expect(error).toBeUndefined();
         }).then(done);
@@ -86,7 +94,7 @@ describe("ConnectorDB admin user", function () {
 
     it("should be able to read stream", function (done) {
         cdb.readStream("javascript_test", "testdevice", "mystream").then(function (result) {
-            expect(result.downlink).toBeUndefined();
+            expect(result.downlink).toBe(false);
             expect(result.name).toBe("mystream")
         }).catch(function (error) {
             expect(error).toBeUndefined();


### PR DESCRIPTION
This sets us up to work with the current ConnectorDB instance. It doesn't have support for dataset queries which should probably wait for emca6 or moving over to TypeScript so we can use OO for the embedded structs in connectordb.
